### PR TITLE
Group aliases diff should be suppressed when only the order is changed

### DIFF
--- a/internal/provider/resource_dynamic_group.go
+++ b/internal/provider/resource_dynamic_group.go
@@ -94,11 +94,11 @@ func resourceDynamicGroup() *schema.Resource {
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(0, 4096)),
 			},
 			"labels": {
-				Description: "One or more label entries that apply to the Group. Currently supported labels contain a key with an empty value.",
-				Type:        schema.TypeMap,
-				Optional:    true,
-				Computed:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description:      "One or more label entries that apply to the Group. Currently supported labels contain a key with an empty value.",
+				Type:             schema.TypeMap,
+				Optional:         true,
+				Computed:         true,
+				Elem:             &schema.Schema{Type: schema.TypeString},
 				DiffSuppressFunc: suppressDynamicLabel,
 			},
 		},
@@ -375,11 +375,11 @@ func convertInterfaceMapToStringMap(input map[string]interface{}) (map[string]st
 }
 
 func suppressDynamicLabel(k, old, new string, d *schema.ResourceData) bool {
-    labelKey := strings.TrimPrefix(k, "labels.")
+	labelKey := strings.TrimPrefix(k, "labels.")
 
-    if labelKey == "cloudidentity.googleapis.com/groups.dynamic" {
-        // Suppress the diff for the API-added label
-        return true
-    }
-    return false
+	if labelKey == "cloudidentity.googleapis.com/groups.dynamic" {
+		// Suppress the diff for the API-added label
+		return true
+	}
+	return false
 }

--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -87,6 +87,7 @@ func resourceGroup() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+				DiffSuppressFunc: diffSuppressAliases,
 			},
 			"non_editable_aliases": {
 				Description: "asps.list of the group's non-editable alias email addresses that are outside of the " +


### PR DESCRIPTION
Hello there,

this PR is related to https://github.com/SamuZad/terraform-provider-googleworkspace/pull/7 since groups can also have aliases and also might be sorted incorrectly.

![image](https://github.com/user-attachments/assets/76f721f4-7c75-4dab-a1a2-0557cb1c2dad)

After editing I ran `make fmt` therefore there are also formatting changes in `internal/provider/resource_dynamic_group.go`.

Let me know if this can be merged.

Cheers

Sebastian