### PR TITLE
group_settings: remove from state on 404 instead of erroring during read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 0.8.0 (Unreleased)
+
+BUG FIXES:
+
+* directory: `googleworkspace_group_settings` is now removed from state on a 404 read (e.g. when its group is deleted outside Terraform) instead of failing the plan ([#30](https://github.com/SamuZad/terraform-provider-googleworkspace/pull/30))
+
 ## 0.7.0 (June 10, 2022)
 
 FEATURES:

--- a/internal/provider/resource_group_settings.go
+++ b/internal/provider/resource_group_settings.go
@@ -472,7 +472,7 @@ func resourceGroupSettingsRead(ctx context.Context, d *schema.ResourceData, meta
 
 	group, err := groupsService.Get(d.Id()).Do()
 	if err != nil {
-		return diag.FromErr(err)
+		return handleNotFoundError(err, d, d.Get("email").(string))
 	}
 
 	// Convert strings to bools

--- a/internal/provider/resource_group_settings_test.go
+++ b/internal/provider/resource_group_settings_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccResourceGroupSettings_basic(t *testing.T) {
@@ -40,6 +41,70 @@ func TestAccResourceGroupSettings_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+// group_settings can only 404 once its group is gone, so the group is deleted
+// out-of-band here.
+func TestAccResourceGroupSettings_disappears(t *testing.T) {
+	t.Parallel()
+
+	domainName := os.Getenv("GOOGLEWORKSPACE_DOMAIN")
+
+	if domainName == "" {
+		t.Skip("GOOGLEWORKSPACE_DOMAIN needs to be set to run this test")
+	}
+
+	testGroupVals := map[string]interface{}{
+		"domainName": domainName,
+		"email":      fmt.Sprintf("tf-test-%s", acctest.RandString(10)),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceGroupSettings_basic(testGroupVals),
+			},
+			{
+				Config: testAccResourceGroupSettings_basic(testGroupVals),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDeleteGroupOutOfBand("googleworkspace_group.my-group"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccDeleteGroupOutOfBand(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("%s key not found in state", resourceName)
+		}
+
+		client, err := googleworkspaceTestClient()
+		if err != nil {
+			return err
+		}
+
+		directoryService, diags := client.NewDirectoryService()
+		if diags.HasError() {
+			return fmt.Errorf("Error creating directory service %+v", diags)
+		}
+
+		groupsService, diags := GetGroupsService(directoryService)
+		if diags.HasError() {
+			return fmt.Errorf("Error getting groups service %+v", diags)
+		}
+
+		if err := groupsService.Delete(rs.Primary.ID).Do(); err != nil {
+			return fmt.Errorf("error deleting group out of band (%s): %w", rs.Primary.ID, err)
+		}
+
+		return nil
+	}
 }
 
 func TestAccResourceGroupSettings_full(t *testing.T) {


### PR DESCRIPTION
### Problem

When the group underlying a `googleworkspace_group_settings` resource is deleted outside Terraform, the next `plan`/`refresh` fails hard on the settings read:

```
Error when reading or editing … 404
```

Because the resource is never dropped from state, the plan cannot proceed, and the only recovery is a manual `terraform state rm`.

### Root cause

`resourceGroupSettingsRead` returns the group `Get` error via `diag.FromErr(err)` for every error, including a 404. The sibling `googleworkspace_group` resource already handles this correctly by routing the same call through `handleNotFoundError` (which does `d.SetId("")` and returns), but `group_settings` does not.

### Fix

Route the group `Get` 404 in `resourceGroupSettingsRead` through `handleNotFoundError(err, d, d.Get("email").(string))`, mirroring `resourceGroupRead`. Non-404 errors (and the local `strconv.ParseBool` errors) are unchanged.

### Test

Adds `TestAccResourceGroupSettings_disappears`: creates a group + settings, deletes the group out-of-band via the Directory API, and asserts the refresh drops the settings from state and yields a non-empty plan. Without the fix this step errors on the 404.

### Notes

- No schema or config changes; behavior change is limited to the deleted-outside-Terraform case.
- This is the standard plugin behavior — [HashiCorp's guidance](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) and the framework docs both say `Read` should remove a resource from state when it no longer exists; `resource_group` in this provider already does so.